### PR TITLE
Support using the OSS fonts

### DIFF
--- a/Extraction.podspec
+++ b/Extraction.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Extraction"
-  s.version      = "1.2.1"
+  s.version      = "1.2.2"
   s.summary      = "UI components shared between Eigen and Emission."
   s.homepage     = "https://github.com/artsy/extraction"
   s.license      = "MIT"
@@ -12,7 +12,12 @@ Pod::Spec.new do |s|
 
   s.subspec 'ARSwitchView' do |ss|
     ss.source_files = 'Extraction/Classes/ARSwitchView.{h,m}'
-    ss.dependency 'Artsy+UIFonts', '>= 1.1.0'
+    if ENV['ARTSY_STAFF_MEMBER'] != nil || ENV['CI'] != nil
+      ss.dependency 'Artsy+UIFonts', '>= 1.1.0'
+    else
+      ss.dependency 'Artsy+OSSUIFonts'
+    end
+
     ss.dependency 'Artsy+UIColors'
     ss.dependency 'FLKAutoLayout'
     ss.dependency 'UIView+BooleanAnimations'


### PR DESCRIPTION
We've been having trouble with people trying to clone our OSS:

* https://github.com/artsy/eigen/issues/2089
* https://github.com/artsy/eigen/issues/2088 
* https://github.com/artsy/emission/issues/418

Extraction is the issue, and unfortunately @alloy you're gonna have to learn to not use `pod repo push` with `--json`  in our repos. 

### What is up with that?

First up, we needed to have a repo with closed source fonts.

When we first started OSSing our apps, we could use loose dependencies between Pods. Because they all had access to each others headers etc, so you could do:

```objc
#import <Artsy-UIFonts/Artsy-UIFonts.h>
```

even if your library did not specify that it had a dependency on that library. We used this "feature" to have an API compatible `Artsy-UIFonts` and `Artsy-UIOSSFonts` to our other pods. They never directly depended on a fonts library, and so it was assumed that the _app_ would choose the version (e.g. one or the other would be in the Podfile. )

This worked for a time, then Swift and CocoaPods 1.0 came along. Swift forced dynamic frameworks on us, and as a part of this CocoaPods enforced strict connections between dependencies.

So, we used [module names](https://guides.cocoapods.org/syntax/podspec.html#module_name) to ensure that the app / dependent libraries would reference the same Pod target. However, this change means that every library now has to also define it's font deps as something that is set at runtime during `pod install`. You can see [Artsy/UILabels](https://github.com/artsy/Specs/blob/master/Artsy%2BUILabels/2.1.2/Artsy%2BUILabels.podspec#L19-L23) doing it here.

This means, if you do `pod repo push` you bake in the fact that you have an `ARTSY_STAFF` env var and break all our OSS versions :D (or at least anything that touches our React Native )

I'm gonna ship this build up as 1.2.2 once I merge this PR and migrate Eigen/Emission to this 👍 