### PR TITLE
ME-78 Fix non-spinning spinner issue

### DIFF
--- a/Extraction/Classes/ARSpinner.m
+++ b/Extraction/Classes/ARSpinner.m
@@ -9,7 +9,7 @@
 
 @interface ARSpinner ()
 @property (nonatomic, strong) UIView *spinnerView;
-@property (nonatomic, assign) NSInteger deferredAnimationCount;
+@property (nonatomic, assign) BOOL deferredAnimation;
 @end
 
 
@@ -59,7 +59,7 @@
 {
     self.alpha = 0;
     [self startAnimating];
-    
+
     [UIView animateIf:animated duration:0.3:^{
         self.alpha = 1;
     } completion:completion];
@@ -69,7 +69,7 @@
 {
     self.alpha = 1;
     [self stopAnimating];
-    
+
     [UIView animateIf:animated duration:0.3:^{
         self.alpha = 0;
     } completion:completion];
@@ -86,17 +86,18 @@
 - (void)didMoveToSuperview
 {
     [super didMoveToSuperview];
-    if (self.superview && self.deferredAnimationCount) {
-        [self ar_startSpinning:self.deferredAnimationCount];
+    if (self.superview && self.deferredAnimation) {
+        self.deferredAnimation = NO;
+        [self ar_startSpinning];
     }
 }
 
-- (void)animate:(NSInteger)times
+- (void)animate
 {
     if (self.superview) {
-        [self ar_startSpinning:times];
+        [self ar_startSpinning];
     } else {
-        self.deferredAnimationCount = times;
+        self.deferredAnimation = YES;
     }
 }
 

--- a/Extraction/Classes/UIView+ARSpinner.h
+++ b/Extraction/Classes/UIView+ARSpinner.h
@@ -5,9 +5,6 @@
 /// Keeps a view spinning for a _very_ long time.
 - (void)ar_startSpinningIndefinitely;
 
-/// Spin a view x times
-- (void)ar_startSpinning:(NSInteger)times;
-
 /// Stop a spin, with an optional finishing spin
 - (void)ar_stopSpinningInstantly:(BOOL)instant;
 

--- a/Extraction/Classes/UIView+ARSpinner.m
+++ b/Extraction/Classes/UIView+ARSpinner.m
@@ -8,10 +8,11 @@ static NSString * const AnimationKey = @"ARSpinner";
 
 - (void)ar_startSpinningIndefinitely
 {
-    [self ar_startSpinning:LONG_MAX];
+    [self ar_startSpinning:LONG_MAX removedOnCompletion:false];
 }
 
 - (void)ar_startSpinning:(NSInteger)times
+     removedOnCompletion:(BOOL)removedOnCompletion
 {
     CATransform3D rotationTransform = CATransform3DMakeRotation(-1.01f * M_PI, 0, 0, 1.0);
     
@@ -20,6 +21,7 @@ static NSString * const AnimationKey = @"ARSpinner";
     rotationAnimation.duration = RotationDuration;
     rotationAnimation.cumulative = YES;
     rotationAnimation.repeatCount = times;
+    rotationAnimation.removedOnCompletion = removedOnCompletion;
 
     [self.layer addAnimation:rotationAnimation forKey:AnimationKey];
     [ARAnimationContinuation addToLayer:self.layer];
@@ -29,7 +31,7 @@ static NSString * const AnimationKey = @"ARSpinner";
 {
     [self.layer removeAnimationForKey:AnimationKey];
     if (!instant) {
-        [self ar_startSpinning:1];
+        [self ar_startSpinning:1 removedOnCompletion:YES];
     }
     [ARAnimationContinuation removeFromLayer:self.layer];
 }

--- a/Extraction/Classes/UIView+ARSpinner.m
+++ b/Extraction/Classes/UIView+ARSpinner.m
@@ -8,14 +8,14 @@ static NSString * const AnimationKey = @"ARSpinner";
 
 - (void)ar_startSpinningIndefinitely
 {
-    [self ar_startSpinning:LONG_MAX removedOnCompletion:false];
+    [self ar_startSpinning:LONG_MAX removedOnCompletion:NO];
 }
 
 - (void)ar_startSpinning:(NSInteger)times
      removedOnCompletion:(BOOL)removedOnCompletion
 {
     CATransform3D rotationTransform = CATransform3DMakeRotation(-1.01f * M_PI, 0, 0, 1.0);
-    
+
     CABasicAnimation *rotationAnimation = [CABasicAnimation animationWithKeyPath:@"transform"];
     rotationAnimation.toValue = [NSValue valueWithCATransform3D:rotationTransform];
     rotationAnimation.duration = RotationDuration;
@@ -37,4 +37,3 @@ static NSString * const AnimationKey = @"ARSpinner";
 }
 
 @end
-


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/ME-78

I discovered that the animation was being stopped on our behalf by UIKit/CA. Seems to happen reliably in some situations where the spinner goes off-screen temporarily, but only in _some_ such situations. Setting this `removedOnCompletion` flag to `false` prevents it from happening. I also simplified the API a tad.

Weird weird stuff tho 🤔Wonder why it just started happening.

Before

![spinner-bad](https://user-images.githubusercontent.com/1242537/68206335-641ff680-ffc4-11e9-9594-a314dcfb1593.gif)

After

![spinner-good](https://user-images.githubusercontent.com/1242537/68206322-5ff3d900-ffc4-11e9-9dfd-cf762507cd3c.gif)
